### PR TITLE
Fix Sequoia build

### DIFF
--- a/csops/codesign.h
+++ b/csops/codesign.h
@@ -29,6 +29,7 @@
 #ifndef _SYS_CODESIGN_H_
 #define _SYS_CODESIGN_H_
 
+#include <stdint.h>
 #include <sys/types.h>
 
 /* code signing attributes of a process */


### PR DESCRIPTION
Add include file needed when building with the Sequoia SDK installed